### PR TITLE
Compute inputs for transactions with references

### DIFF
--- a/examples/server/app/index.js
+++ b/examples/server/app/index.js
@@ -21,29 +21,34 @@ const app = express()
 let {OmiClient} = require('omi-client')
 // let {signer} = require('sawtooth-sdk')
 
+const BASE_SAWTOOTH_URL = 'http://localhost:8080'
+// This should either be generated once per rest user, or, in the case of reads,
+// is unecessary.
+const PRIVATE_KEY = ''
+
 app.get('/individuals', (req, res) => {
-  let omiClient = new OmiClient('http://localhost:18080', '')
+  let omiClient = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
 
   return omiClient.getIndividuals().all()
                   .then(individuals => res.send(individuals))
 })
 
 app.get('/organizations', (req, res) => {
-  let omiClient = new OmiClient('http://localhost:18080', '')
+  let omiClient = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
 
   return omiClient.getOrganizations().all()
                   .then(organizations => res.send(organizations))
 })
 
 app.get('/works', (req, res) => {
-  let omiClient = new OmiClient('http://localhost:18080', '')
+  let omiClient = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
 
   return omiClient.getWorks().all()
                   .then(works => res.send(works))
 })
 
 app.get('/recordings', (req, res) => {
-  let omiClient = new OmiClient('http://localhost:18080', '')
+  let omiClient = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
 
   return omiClient.getRecordings().all()
                   .then(recordings => res.send(recordings))

--- a/examples/webclient/app/index.js
+++ b/examples/webclient/app/index.js
@@ -18,7 +18,7 @@
 let {OmiClient} = require('omi-client')
 let {signer} = require('sawtooth-sdk')
 
-let sawtoothRestApiBaseUrl = 'http://localhost:18080'
+let sawtoothRestApiBaseUrl = 'http://localhost:8080'
 let privateKey = signer.makePrivateKey()
 
 let client = new OmiClient(sawtoothRestApiBaseUrl, privateKey)

--- a/omi-client/spec/omi_client_spec.js
+++ b/omi-client/spec/omi_client_spec.js
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+'use strict'
+
+const assert = require('assert')
+const request = require('superagent')
+const mock = require('superagent-mocker')(request)
+
+const {BatchList, TransactionHeader} = require('sawtooth-sdk/protobuf')
+
+const {OmiClient} = require('../lib')
+const addressing = require('../lib/addressing')
+const {Recording} = require('../lib/protobuf')
+
+// This is normally a URL, but for testing purposes, an empty string is fine
+const BASE_SAWTOOTH_URL = ''
+const PRIVATE_KEY = 'e8e4109d6e2d0f46984115c297090401a9fa0c2a7e9c72485739d5135cedab20'
+
+describe('OmiClient', () => {
+  beforeEach(() => {
+    mock.clearRoutes()
+  })
+
+  describe('setWork', () => {
+    it('should submit a txn with the correct inputs and outputs', () => {
+      let data = null
+
+      mock.post('/batches', (req) => {
+        data = req.body
+
+        return {
+          body: { link: 'batchstatuslink' }
+        }
+      })
+
+      let client = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
+      return client.setWork({
+        title: 'TestSong',
+        songwriterPublisherSplits: [
+          {
+            split: 100,
+            songwriterPublisher: {
+              songwriterName: 'TestSinger',
+              publisherName: 'TestPublisher'
+            }
+          }
+        ]
+      }).then((statusChecker) => {
+        let {batchId, transactionHeader} = _recoverTransaction(data)
+
+        assert.equal(batchId, statusChecker.batchId)
+
+        assert.deepEqual([_workAddress('TestSong')], transactionHeader.outputs)
+        assert.deepEqual(
+          [
+            _workAddress('TestSong'),
+            _individualAddress('TestSinger'),
+            _orgAddress('TestPublisher')
+          ],
+          transactionHeader.inputs)
+      })
+    })
+  })
+
+  describe('setRecording', () => {
+    it('should submit a txn with the correct inputs and outputs', () => {
+      let data = null
+
+      mock.post('/batches', (req) => {
+        data = req.body
+
+        return {
+          body: { link: 'batchstatuslink' }
+        }
+      })
+
+      let client = new OmiClient(BASE_SAWTOOTH_URL, PRIVATE_KEY)
+      return client.setRecording({
+        title: 'TestRecording',
+        type: Recording.Type.MIX,
+        labelName: 'TestLabel',
+        contributorSplits: [
+          {
+            split: 100,
+            contributorName: 'TestSinger'
+          }
+        ],
+        derivedWorkSplits: [
+          {
+            split: 100,
+            workName: 'TestWork'
+          }
+        ],
+        derivedRecordingSplits: [
+          {
+            split: 100,
+            recordingName: 'TestOtherRecording'
+          }
+        ],
+        overallSplit: {
+          derivedWorkPortion: 33,
+          derivedRecordingPortion: 33,
+          contributorPortion: 34
+        }
+      }).then((statusChecker) => {
+        let {batchId, transactionHeader} = _recoverTransaction(data)
+
+        assert.equal(batchId, statusChecker.batchId)
+
+        assert.deepEqual([_recordingAddress('TestRecording')],
+                         transactionHeader.outputs)
+
+        assert.deepEqual(
+          [
+            _recordingAddress('TestRecording'),
+            _orgAddress('TestLabel'),
+            _individualAddress('TestSinger'),
+            _workAddress('TestWork'),
+            _recordingAddress('TestOtherRecording')
+          ],
+          transactionHeader.inputs)
+      })
+    })
+  })
+})
+
+/**
+ * There is a side-effect due to superagent-mocker that converts the data
+ * to an object.  We need to take the object body and convert it back to a
+ * buffer.
+ */
+let _bodyToBuffer = (body) => {
+  let bufferLength = Object.keys(body).length
+  let buffer = Buffer.alloc(bufferLength)
+  for (var i = 0; i < bufferLength; i++) {
+    buffer.writeUInt8(body[i], i)
+  }
+  return buffer
+}
+
+let _recoverTransaction = (data) => {
+  let batchList = BatchList.decode(_bodyToBuffer(data))
+
+  assert.equal(1, batchList.batches.length)
+  let batch = batchList.batches[0]
+
+  assert.equal(1, batch.transactions.length)
+  let transaction = batch.transactions[0]
+
+  let transactionHeader = TransactionHeader.decode(transaction.header)
+  return {
+    batchId: batch.headerSignature,
+    transaction,
+    transactionHeader
+  }
+}
+
+let _workAddress = (title) => addressing.getObjectAddress('Work', title)
+let _recordingAddress = (title) => addressing.getObjectAddress('Recording', title)
+let _individualAddress = (name) => addressing.getObjectAddress('IndividualIdentity', name)
+let _orgAddress = (name) => addressing.getObjectAddress('OrganizationalIdentity', name)

--- a/omi/sawtooth_omi/handler.py
+++ b/omi/sawtooth_omi/handler.py
@@ -58,8 +58,8 @@ def get_tag(action):
         if action in action_group:
             return tags[action_group]
 
-# address
 
+# address
 def _hash_name(name):
     return hashlib.sha512(name.encode('utf-8')).hexdigest()
 
@@ -232,7 +232,7 @@ def _check_split_sums(obj, tag):
         overall_sum = sum([
             overall.derived_work_portion,
             overall.derived_recording_portion,
-            overall.contributor_portion,])
+            overall.contributor_portion])
 
         if overall_sum != 100:
             raise InvalidTransaction(
@@ -314,9 +314,8 @@ def _check_references(state, obj, tag):
             contributor = contributor_split.contributor_name
             if _get_state_object(state, contributor, INDIVIDUAL) is None:
                 raise InvalidTransaction(
-                    'Recording "{t}" references unknown contributor "{c}"'.format(
-                        t=obj.title,
-                        c=contributor))
+                    'Recording "{t}" references unknown contributor '
+                    '"{c}"'.format(t=obj.title, c=contributor))
 
         # check derived works
         for derived_work_split in obj.derived_work_splits:
@@ -332,12 +331,11 @@ def _check_references(state, obj, tag):
             recording = derived_recording_split.recording_name
             if _get_state_object(state, recording, RECORDING) is None:
                 raise InvalidTransaction(
-                    'Recording "{t}" references unknown recording "{r}"'.format(
-                        t=obj.title,
-                        r=recording))
+                    'Recording "{t}" references unknown recording '
+                    '"{r}"'.format(t=obj.title, r=recording))
+
 
 # state
-
 def _get_state_object(state, name, tag):
     try:
         address = make_omi_address(name, tag)


### PR DESCRIPTION
Compute the input addresses for Transactions where the object being set has references to other OMI objects (e.g. DerivedWorkSplits in Recording).

* Added tests
* Set example port to 8080 (the default REST API port)