### PR TITLE
Fixes for github installs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 omi-client/dependencies/
 omi/
-protos/
 bin/

--- a/omi-client/scripts/compile_protobuf.js
+++ b/omi-client/scripts/compile_protobuf.js
@@ -21,8 +21,7 @@ const path = require('path')
 const fs = require('fs')
 
 const protobuf = require('protobufjs')
-const jsonTarget = require(
-  path.resolve(__dirname, '../../node_modules/protobufjs/cli/targets/json'))
+const jsonTarget = require('protobufjs/cli/targets/json')
 
 const protoDir = path.resolve(__dirname, '../../protos')
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "standard && mocha --recursive omi-client/spec --compilers js:babel-register -r babel-polyfill",
     "watch:test": "mocha -w --recursive omi-client/spec --compilers js:babel-register -r babel-polyfill",
     "prepublish":": npm run compile-protobuf",
-    "postinstall": "./omi-client/scripts/install_sawtooth_sdk.sh",
+    "postinstall": "npm run compile-protobuf && ./omi-client/scripts/install_sawtooth_sdk.sh",
     "build-docs": "mkdir -p omi-client/docs && jsdoc -c jsdoc_conf.json -d ./omi-client/docs ./omi-client/README.md"
   },
   "author": "",


### PR DESCRIPTION
This fixes an issue where installs using the github url for the `npm install<omi-github-url>` would not correctly build protobufs. 