### PR TITLE
Add "Usage" section to omi-client/README

### DIFF
--- a/omi-client/README.md
+++ b/omi-client/README.md
@@ -1,6 +1,6 @@
-# OMI Summer Lab Javascript SDK
+# OMI Summer Lab JavaScript SDK
 
-The OMI Summer Lab Javascript SDK provides a simple client to submit and fetch
+The OMI Summer Lab JavaScript SDK provides a simple client to submit and fetch
 values to a Hyperledger Sawtooth blockchain.
 
 ## Getting Started
@@ -13,7 +13,12 @@ In your project, install the `omi-client` using the github repository location:
 $ npm install IntelLedger/omi-summer-lab
 ```
 
-You will also need to install the underlying sawtooth-sdk  dependency, which
+> Note, some of the underlying packages are built with
+> [prebuild](https://github.com/mafintosh/prebuild).  Installs will be much
+> faster if you install
+> [prebuild-install](https://github.com/mafintosh/prebuild-install).
+
+You will also need to install the underlying sawtooth-sdk dependency, which
 will have been included as part of the omi-summer-lab installation. Run the
 following step:
 
@@ -29,8 +34,8 @@ installations.
 
 If you are using a tool like Webpack, you will need to include an alias for the
 zeromq library, which cannot be included in the browser. A mock module has been
-included with the omi client installation, and can be referenced in your webpack
-configuration file (see `examples/webclient/webpack.config.js`).
+included with the `omi-client` installation, and can be referenced in your
+webpack configuration file (see `examples/webclient/webpack.config.js`).
 
 A `webpack.config.js` should include the following:
 
@@ -46,7 +51,106 @@ A `webpack.config.js` should include the following:
 
 ## Usage
 
-Forthcoming
+To submit items to the block chain, or read existing items value off the global
+state, you must create an `OmiClient`.  It can be created with a private key you
+can generate, or one that has been saved to disk.
+
+```
+let {OmiClient} = require('omi-client')
+let {signer} = require('sawtooth-sdk')
+
+const sawtoothBaseUrl = 'http://localhost:8080'
+const privateKey = signer.makePrivateKey() // or load existing key from some other source
+
+let client = new OmiClient(sawtoothBaseUrl, privateKey)
+```
+
+### Setting Objects
+
+Objects are set in the global state via a transaction submitted to the block
+chain. These objects are `IndividualIdentity`, `OrganizationalIdentity`,
+`Recording`, and `Work`. Each has a corresponding `set` method on the
+`OmiClient`: `setIndividual` for `IndividualIdentity`, and so on.
+
+Initial sets of an object result in a new object being stored in the global
+state.  Subsequent sets of an object result in an update operation.  These
+updates may only be performed by the owner of the private key that signed the
+original set operation.  In other words, ownership of the object is controlled
+by the public key associated with the private key used to create it.
+
+`OrganizationalIdentity` and `Recordings` both have type enumerations.  These
+can be accessed via
+
+```
+let {OrganizationalIdentity, Recording} = require('omi-client/protobuf')
+
+// and used like so (with an Organization example):
+
+client.setOrganization({
+  name: 'Sawtooth Music Group',
+  type: OrganizationalIdentity.Type.LABEL
+}).then((statusChecker) => {
+  // ...
+})
+```
+
+#### Checking Commit Status
+
+As seen in the above example, any `set` method returns a JavaScript Promise for
+the current status of the transaction submission.  A call to its `check` method
+will request the status, returning either `"COMMITTED"` or `"PENDING"`, in the
+case of a time out.
+
+For example:
+
+```
+client.setIndividual({ /* some fields */ })
+      .then((statusChecker) => status.check())
+      .then((status) => {
+        if (status == 'COMMITTED') {
+          // update a UI or log a message
+        } else {
+          // Pending - check again, or consider the transaction a failure
+        }
+      })
+```
+
+### Reading Objects
+
+Objects in the global state each have a pair of methods for reading values: a
+get-by-id method and a get-list method.  Like set, there is one for each OMI
+Object: `getIndividual` for a single `IndividualIdentity`, and `getIndividuals`
+for a cursor into a list of `IndividualIdentity`.  `OrganizationalIdentity`,
+`Recording`, and `Work` follow suit.
+
+To get all individuals, for example:
+
+```
+client.getIndividuals().all().then((individuals) => {
+   // print or update a UI of individuals
+})
+```
+
+To iterator over the individuals, for example:
+
+```
+client.getIndividuals().each((err, individual) => {
+  if (err) {
+     console.log('Error occurred reading an individual', err)
+  }
+
+  // print or update a UI individual. E.g.
+  console.log(`Individual ${individual.name}`)
+})
+```
+
+An specific individual can be fetched by its natural key, in this case name:
+
+```
+client.getIndividual('David Bowie').then((individual) => {
+   console.log(individual.ISNI)
+})
+```
 
 ## Development
 
@@ -62,6 +166,15 @@ To run the unit tests:
 ```
 $ npm test
 ```
+
+To build the docs:
+
+```
+$ npm run build-docs
+```
+
+The generated docs can be found in `<omi-summer-lab>/omi-client/docs`.
+
 
 
 ## License

--- a/omi-client/lib/addressing.js
+++ b/omi-client/lib/addressing.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @module omi-summer-lab/addressing
+ * @module omi-client/addressing
  */
 const _crypto = require('crypto')
 

--- a/omi-client/lib/index.js
+++ b/omi-client/lib/index.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @module omi-summer-lab
+ * @module omi-client
  */
 
 const request = require('superagent')

--- a/omi-client/lib/protobuf/index.js
+++ b/omi-client/lib/protobuf/index.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @module omi-summer-lab/protobuf
+ * @module omi-client/protobuf
  */
 
 const _protobuf = require('protobufjs/light')
@@ -32,32 +32,114 @@ module.exports = {
   /**
    * This is a Protobuf Message for IndividualIdentity.
    *
+   * Functionally, the properties are equivalent to:
+   *
+   * ```
+   * {
+   *   "name": "String", // a Unique name; the natural key
+   *   "IPI": "International Parties Information", // may be null
+   *   "ISNI": "International Standard Name Identifier", // may be null
+   *   "street_address": "street address for payments", // may be null
+   *   "pubkey": "creators pub key in hex" // matches the signer's pubkey
+   * }
+   * ```
+   *
    * @kind class
-   * @extendsMessage
+   * @extends Message
    */
   IndividualIdentity: _root.lookup('IndividualIdentity'),
 
   /**
    * This is a Protobuf Message for OrganizationalIdentity.
    *
+   * Functionally, the properties are equivalent to:
+   *
+   * ```
+   * {
+   *   "name": "String", // a Unique name; its natural key
+   *   "type": OrganizationalIdentity.LABEL | OrganizationalIdentity.PUBLISHER,
+   *   "IPI": "International Parties Information", // may be null
+   *   "street_address": "street address for payments", // may be null
+   * }
+   * ```
+   *
    * @kind class
-   * @extendsMessage
+   * @extends Message
    */
   OrganizationalIdentity: _root.lookup('OrganizationalIdentity'),
 
   /**
    * This is a Protobuf Message for Recording.
    *
+   * Functionally, the properties are equivalent to:
+   *
+   * ```
+   * {
+   *   "title": "String", // The title of the Recording (its natural key)
+   *   "type": <an int>, // The value of which is a Recording.Type
+   *   "ISRC": "International Standard Recording Code", // can be null
+   *   "labelName": "Org.name of type LABEL", // can be null
+   *   "contributorSplits": [
+   *     {
+   *       // all splits in this list must add up to 100
+   *       "split": <a positive int>,
+   *       "contributorName": "An IndividualIdentity.name"
+   *     },
+   *     // and more
+   *   ],
+   *   derivedWorkSplits: [
+   *     {
+   *       // all splits in this list must add up to 100
+   *       "split": <a positive int>,
+   *       "workName": "A Work.name"
+   *     },
+   *   ],
+   *   derivedRecordingSplits: [
+   *     {
+   *       // all splits in this list must add up to 100
+   *       "split": <a positive int>,
+   *       "recordingName": "A Recording.name"
+   *     },
+   *   ],
+   *   overallSplit: {
+   *      // all splits in this list must add up to 100
+   *     "derivedWorkPortion": <a positive int>,
+   *     "derivedRecordingPortion": <a positive int>,
+   *     "contributorPortion": <a positive int>
+   *   }
+   * }
+   * ```
+   *
    * @kind class
-   * @extendsMessage
+   * @extends Message
    */
   Recording: _root.lookup('Recording'),
 
   /**
    * This is a Protobuf Message for Work.
    *
+   * Functionally, the properties are equivalent to:
+   *
+   * ```
+   * {
+   *   "title": "String", // a unique title of the work; the natural key
+   *   "ISWC": "International Standard Work Code", // may be null
+   *   "songwriterPublisherSplits": [
+   *     {
+   *       // all splits in this list must add up to 100
+   *       "split": <a positive int>,
+   *       "songwriterPublisher": {
+   *         "songwriterName": "IndividualIdentity.name",
+   *         "publisherName": "OrganizationalIdentity.name" // must be Type.PUBLISHER
+   *       }
+   *     },
+   *     // and more
+   *   ]
+   * }
+   * ```
+   *
    * @kind class
-   * @extendsMessage
+   * @extends Message
    */
   Work: _root.lookup('Work'),
 
@@ -65,7 +147,7 @@ module.exports = {
    * This is a ProtobufMessage for the OMITransactionPayload.
    *
    * @kind class
-   * @extendsMessage
+   * @extends Message
    */
   OMITransactionPayload: _root.lookup('OMITransactionPayload')
 }


### PR DESCRIPTION
Add the "Usage" section with the following purpose:

* Usage for submitting objects
* Usage for get lists of objects
* Usage for get single objects

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>