### PR TITLE
Add JSDoc to doc build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,17 +52,20 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
-html:
+jsdoc:
+	cd .. && npm run build-docs
+
+html: jsdoc
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: jsdoc
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
+singlehtml: jsdoc
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -4,4 +4,6 @@ Table of Contents
 
 .. toctree::
 
+   getting_started.rst
+
    transaction_family_specification.rst

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,7 @@
+***************
+Getting Started
+***************
+
+
+See the `OMI JavaScript SDK <omi_client/index.html>`__.
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch:test": "mocha -w --recursive omi-client/spec --compilers js:babel-register -r babel-polyfill",
     "prepublish":": npm run compile-protobuf",
     "postinstall": "npm run compile-protobuf && ./omi-client/scripts/install_sawtooth_sdk.sh",
-    "build-docs": "mkdir -p omi-client/docs && jsdoc -c jsdoc_conf.json -d ./omi-client/docs ./omi-client/README.md"
+    "build-docs": "jsdoc -c jsdoc_conf.json -d ./docs/build/html/omi_client ./omi-client/README.md"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Move the jsdocs output to the html sphinx dir
Add a placeholder getting started page, which references the JS doc