### PR TITLE
Add client js sdk docs to sphinx doc

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -1,13 +1,22 @@
 {%- extends "layout.html" %}
-{% set title = 'Overview' %}
+{% set title = 'OMI Summer Lab' %}
 {% block body %}
 
   <h1>OMI Summer Lab</h1>
 
-  <p class="biglink"><a class="biglink" href="{{ pathto("getting_started")
-    }}">{% trans %}Getting Started{% endtrans %}</a><br/>
-    <span class="linkdescr">{% trans %}gettting started with OMI Summer Lab on
+  <p class="biglink"><a class="biglink" href="{{ pathto("welcome")
+    }}">{% trans %}Welcome to OMI Summer Lab{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}Learn about OMI Summer Lab on
       Hyperledger Sawtooth{% endtrans %}</span></p>
 
+  <p class="biglink"><a class="biglink" href="{{ pathto("getting_started")
+    }}">{% trans %}Getting Started{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}Gettting started with OMI Summer Lab on
+      Hyperledger Sawtooth{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("omi_client")
+    }}">{% trans %}OMI Client JavaScript SDK{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}Using the OMI JavaScript Client SDK
+      {% endtrans %}</span></p>
 
 {% endblock %}

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -6,4 +6,6 @@ Table of Contents
 
    getting_started.rst
 
+   omi_client.rst
+
    transaction_family_specification.rst

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -4,6 +4,8 @@ Table of Contents
 
 .. toctree::
 
+   welcome.rst
+
    getting_started.rst
 
    omi_client.rst

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -2,6 +2,55 @@
 Getting Started
 ***************
 
+This guide will help you get started with Hyperledger Sawtooth and the OMI
+Summer Lab Transaction Processor.
+
+Getting the Source
+******************
+
+OMI Summer Lab is made available via the source repository.  This repository is
+hosted on `Github <https://github.com/IntelLedger/omi-summer-lab>`__.
+
+You will need to have `git` installed on your system. If you need help setting
+this up, you'll find a handy guide `here
+<https://help.github.com/articles/set-up-git/>`__.
+
+.. note::
+
+  On Mac OS, `git` is already installed, but if you haven't used it, you may
+  need to run, in the terminal:
+
+  .. code-block:: console
+
+    $ xcode-select --install
+
+To clone the repository:
+
+.. code-block:: console
+
+  $ git clone https://github.com/IntelLedger/omi-summer-lab
+  Cloning into 'omi-summer-lab'...
+  remote: Counting objects: 403, done.
+  remote: Compressing objects: 99% (153/153), done.
+  remote: Total 403 (delta 66), reused 199 (delta 59), pack-reused 186
+  Receiving objects: 99% (404/404), 1.93 MiB | 952.00 KiB/s, done.
+  Resolving deltas: 99% (124/124), done.
+
+
+You'll find the Transaction Processor source in `omi-summer-lab/omi` and the
+JavaScript client library source in `omi-summer-lab/omi-client`.
+
+Using Docker Compose
+********************
+
+Docker is an open-source project for running applications in a software
+container.  We provide several docker containers for running the various
+components of Hyperledger sawtooth, as well as the OMI Summer Lab Transaction
+Processor. All of these containers can be started in concert by using Docker
+Compose.
+
+Required Tools
+==============
 
 The following tools are required:
 
@@ -9,17 +58,19 @@ The following tools are required:
   or later)
 * `Docker Compose <https://docs.docker.com/compose/install/>`_ (Linux only)
 
+Starting Up Hyperledger Sawtooth
+================================
+
 To start a validator node running the OMI transaction handler, run:
 
 .. code-block:: console
 
   % docker-compose -f omi-summer-lab/docker/compose-with-omi.yaml up
 
-This will start a validator, a config transaction handler, an OMI transaction handler, and a REST API instance with which a client can communicate. To stop the validator node, press Ctrl-c and then run 
+This will start a validator, a config transaction handler, an OMI transaction
+handler, and a REST API instance with which a client can communicate. To stop
+the validator node, press Ctrl-c and then run:
 
 .. code-block:: console
 
   % docker-compose -f omi-summer-lab/docker/compose-with-omi.yaml down
-
-
-See the `OMI JavaScript SDK <omi_client/index.html>`__.

--- a/docs/source/omi_client.rst
+++ b/docs/source/omi_client.rst
@@ -1,0 +1,192 @@
+*************************
+OMI Client JavaScript SDK
+*************************
+
+The OMI Summer Lab JavaScript SDK provides a simple client to submit and fetch
+values to a Hyperledger Sawtooth blockchain.
+
+See the `OMI JavaScript SDK JSDoc <omi_client/index.html>`__.
+
+Getting Started
+***************
+
+.. note::
+
+  **Requires Node 6.x or greater.**
+
+In your project, install the `omi-client` using the github repository location:
+
+.. code-block:: console
+
+  $ npm install IntelLedger/omi-summer-lab
+
+.. note::
+
+  Note, some of the underlying packages are built with
+  `prebuild <https://github.com/mafintosh/prebuild>`__.  Installs will be much
+  faster if you install
+  `prebuild-install <https://github.com/mafintosh/prebuild-install>`__.
+
+You will also need to install the underlying sawtooth-sdk dependency, which
+will have been included as part of the omi-summer-lab installation. Run the
+following step:
+
+.. code-block:: console
+
+  $ npm install ./node_modules/omi-client/omi-client/dependencies/sawtooth-core/sdk/javascript
+
+This can be added to your `package.json` as a `postinstall` step, for future
+installations.
+
+Webpack configuration
+=====================
+
+If you are using a tool like Webpack, you will need to include an alias for the
+zeromq library, which cannot be included in the browser. A mock module has been
+included with the `omi-client` installation, and can be referenced in your
+webpack configuration file (see `examples/webclient/webpack.config.js`).
+
+A `webpack.config.js` should include the following:
+
+.. code-block:: javascript
+
+    // ...
+    resolve: {
+      alias: {
+        zeromq$: path.resolve(__dirname, './node_modules/omi-client/omi-client/lib/mock_zeromq.js')
+      }
+    }
+    // ...
+
+Usage
+*****
+
+To submit items to the block chain, or read existing items value off the global
+state, you must create an `OmiClient`.  It can be created with a private key you
+can generate, or one that has been saved to disk.
+
+.. code-block:: javascript
+
+  let {OmiClient} = require('omi-client')
+  let {signer} = require('sawtooth-sdk')
+
+  const sawtoothBaseUrl = 'http://localhost:8080'
+  const privateKey = signer.makePrivateKey() // or load existing key from some other source
+
+  let client = new OmiClient(sawtoothBaseUrl, privateKey)
+
+Setting Objects
+===============
+
+Objects are set in the global state via a transaction submitted to the block
+chain. These objects are `IndividualIdentity`, `OrganizationalIdentity`,
+`Recording`, and `Work`. Each has a corresponding `set` method on the
+`OmiClient`: `setIndividual` for `IndividualIdentity`, and so on.
+
+Initial sets of an object result in a new object being stored in the global
+state.  Subsequent sets of an object result in an update operation.  These
+updates may only be performed by the owner of the private key that signed the
+original set operation.  In other words, ownership of the object is controlled
+by the public key associated with the private key used to create it.
+
+`OrganizationalIdentity` and `Recordings` both have type enumerations.  These
+can be accessed via
+
+.. code-block:: javascript
+
+  let {OrganizationalIdentity, Recording} = require('omi-client/protobuf')
+
+  // and used like so (with an Organization example):
+
+  client.setOrganization({
+    name: 'Sawtooth Music Group',
+    type: OrganizationalIdentity.Type.LABEL
+  }).then((statusChecker) => {
+    // ...
+  })
+
+Checking Commit Status
+----------------------
+
+As seen in the above example, any `set` method returns a JavaScript Promise for
+the current status of the transaction submission.  A call to its `check` method
+will request the status, returning either `"COMMITTED"` or `"PENDING"`, in the
+case of a time out.
+
+For example:
+
+.. code-block:: javascript
+
+  client.setIndividual({ /* some fields */ })
+        .then((statusChecker) => status.check())
+        .then((status) => {
+          if (status == 'COMMITTED') {
+            // update a UI or log a message
+          } else {
+            // Pending - check again, or consider the transaction a failure
+          }
+        })
+
+Reading Objects
+===============
+
+Objects in the global state each have a pair of methods for reading values: a
+get-by-id method and a get-list method.  Like set, there is one for each OMI
+Object: `getIndividual` for a single `IndividualIdentity`, and `getIndividuals`
+for a cursor into a list of `IndividualIdentity`.  `OrganizationalIdentity`,
+`Recording`, and `Work` follow suit.
+
+To get all individuals, for example:
+
+.. code-block:: javascript
+
+  client.getIndividuals().all().then((individuals) => {
+     // print or update a UI of individuals
+  })
+
+To iterator over the individuals, for example:
+
+.. code-block:: javascript
+
+  client.getIndividuals().each((err, individual) => {
+    if (err) {
+       console.log('Error occurred reading an individual', err)
+    }
+
+    // print or update a UI individual. E.g.
+    console.log(`Individual ${individual.name}`)
+  })
+
+An specific individual can be fetched by its natural key, in this case name:
+
+.. code-block:: javascript
+
+  client.getIndividual('David Bowie').then((individual) => {
+     console.log(individual.ISNI)
+  })
+
+Development
+***********
+
+Checkout the repo and cd to `<omi-summer-lab>/` and type:
+
+.. code-block:: console
+
+  $ npm install
+  $ npm run compile-protobuf
+
+To run the unit tests:
+
+.. code-block:: console
+
+  $ npm test
+
+
+To build the docs:
+
+.. code-block:: console
+
+  $ npm run build-docs
+
+
+The generated docs can be found in `<omi-summer-lab>/omi-client/docs`.

--- a/docs/source/welcome.rst
+++ b/docs/source/welcome.rst
@@ -1,0 +1,22 @@
+*************************
+Welcome to OMI Summer Lab
+*************************
+
+
+Welcome to the OMI Summer Lab! This document will get you started with
+Hyperledger Sawtooth, a blockchain development platform. Blockchains form the
+underlying technology of cryptocurrencies like Bitcoin and Ethereum, and offer
+unique capabilities for providing trustworthy copies of data between
+potentially adversarial parties.
+
+To support the OMI Summer Lab, the Sawtooth team has built a sample Transaction
+Processor and JavaScript client allowing for the representation of musical
+Works and Recordings on the blockchain. This documentation will help you get
+started running a local instance of Hyperledger Sawtooth with the OMI
+transaction processor on your development machine. From there, you can build
+apps on top of the JavaScript client in node.js or in a web browser and extend
+the sample transaction processor to support new transaction types and data
+formats.
+
+To learn more about Hyperledger Sawtooth, you can explore the `documentation
+<https://intelledger.github.io>`__.


### PR DESCRIPTION
Add the client js documentation to the sphinx doc, for cleaner
readability.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>